### PR TITLE
refactor: 커서 페이지네이션 안정화 및 복합 인덱스 추가

### DIFF
--- a/perf-backend/src/main/java/eottabom/perf/core/CursorUtils.java
+++ b/perf-backend/src/main/java/eottabom/perf/core/CursorUtils.java
@@ -6,6 +6,6 @@ public final class CursorUtils {
 	}
 
 	public static String normalizeCursorId(String afterId) {
-		return (afterId == null || afterId.isBlank()) ? "~" : afterId;
+		return (afterId == null || afterId.isBlank()) ? "~" : afterId.trim();
 	}
 }

--- a/perf-backend/src/main/java/eottabom/perf/core/CursorUtils.java
+++ b/perf-backend/src/main/java/eottabom/perf/core/CursorUtils.java
@@ -1,0 +1,11 @@
+package eottabom.perf.core;
+
+public final class CursorUtils {
+
+	private CursorUtils() {
+	}
+
+	public static String normalizeCursorId(String afterId) {
+		return (afterId == null || afterId.isBlank()) ? "~" : afterId;
+	}
+}

--- a/perf-backend/src/main/java/eottabom/perf/core/RunService.java
+++ b/perf-backend/src/main/java/eottabom/perf/core/RunService.java
@@ -18,6 +18,8 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static eottabom.perf.core.CursorUtils.normalizeCursorId;
+
 @Service
 public class RunService {
 
@@ -70,10 +72,6 @@ public class RunService {
 		return runs.stream()
 				.map(run -> RunResponse.from(run, scenarioMap.get(run.scenarioId())))
 				.toList();
-	}
-
-	private static String normalizeCursorId(String afterId) {
-		return (afterId == null || afterId.isBlank()) ? "~" : afterId;
 	}
 
 	public RunResponse findById(String id) {

--- a/perf-backend/src/main/java/eottabom/perf/core/RunService.java
+++ b/perf-backend/src/main/java/eottabom/perf/core/RunService.java
@@ -60,7 +60,7 @@ public class RunService {
 	public List<RunResponse> findAll(LocalDateTime after, String afterId, int size) {
 		var runs = after == null
 				? runRepository.findFirst(size)
-				: runRepository.findAfter(after, afterId, size);
+				: runRepository.findAfter(after, normalizeCursorId(afterId), size);
 
 		// N+1 쿼리 방지: 시나리오를 한 번에 배치 조회
 		var scenarioIds = runs.stream().map(Run::scenarioId).collect(Collectors.toSet());
@@ -70,6 +70,10 @@ public class RunService {
 		return runs.stream()
 				.map(run -> RunResponse.from(run, scenarioMap.get(run.scenarioId())))
 				.toList();
+	}
+
+	private static String normalizeCursorId(String afterId) {
+		return (afterId == null || afterId.isBlank()) ? "~" : afterId;
 	}
 
 	public RunResponse findById(String id) {

--- a/perf-backend/src/main/java/eottabom/perf/core/ScenarioService.java
+++ b/perf-backend/src/main/java/eottabom/perf/core/ScenarioService.java
@@ -28,7 +28,7 @@ public class ScenarioService {
 	public List<Scenario> findAll(LocalDateTime after, String afterId, int size) {
 		return after == null
 				? scenarioRepository.findFirst(size)
-				: scenarioRepository.findAfter(after, afterId, size);
+				: scenarioRepository.findAfter(after, normalizeCursorId(afterId), size);
 	}
 
 	public List<Scenario> findAllById(Collection<String> ids) {
@@ -75,5 +75,9 @@ public class ScenarioService {
 			throw new IllegalStateException("Scenario has runs and cannot be deleted: " + id);
 		}
 		scenarioRepository.deleteById(id);
+	}
+
+	private static String normalizeCursorId(String afterId) {
+		return (afterId == null || afterId.isBlank()) ? "~" : afterId;
 	}
 }

--- a/perf-backend/src/main/java/eottabom/perf/core/ScenarioService.java
+++ b/perf-backend/src/main/java/eottabom/perf/core/ScenarioService.java
@@ -13,6 +13,8 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 
+import static eottabom.perf.core.CursorUtils.normalizeCursorId;
+
 @Service
 public class ScenarioService {
 
@@ -75,9 +77,5 @@ public class ScenarioService {
 			throw new IllegalStateException("Scenario has runs and cannot be deleted: " + id);
 		}
 		scenarioRepository.deleteById(id);
-	}
-
-	private static String normalizeCursorId(String afterId) {
-		return (afterId == null || afterId.isBlank()) ? "~" : afterId;
 	}
 }

--- a/perf-backend/src/main/resources/schema.sql
+++ b/perf-backend/src/main/resources/schema.sql
@@ -18,10 +18,8 @@ CREATE TABLE IF NOT EXISTS runs (
         FOREIGN KEY (scenario_id) REFERENCES scenarios(id)
 );
 
-CREATE INDEX IF NOT EXISTS idx_scenarios_created_at ON scenarios(created_at);
 CREATE INDEX IF NOT EXISTS idx_scenarios_created_at_id ON scenarios(created_at DESC, id DESC);
 
 CREATE INDEX IF NOT EXISTS idx_runs_scenario_id ON runs(scenario_id);
 CREATE INDEX IF NOT EXISTS idx_runs_status      ON runs(status);
-CREATE INDEX IF NOT EXISTS idx_runs_started_at  ON runs(started_at);
 CREATE INDEX IF NOT EXISTS idx_runs_started_at_id ON runs(started_at DESC, id DESC);

--- a/perf-backend/src/main/resources/schema.sql
+++ b/perf-backend/src/main/resources/schema.sql
@@ -19,7 +19,9 @@ CREATE TABLE IF NOT EXISTS runs (
 );
 
 CREATE INDEX IF NOT EXISTS idx_scenarios_created_at ON scenarios(created_at);
+CREATE INDEX IF NOT EXISTS idx_scenarios_created_at_id ON scenarios(created_at DESC, id DESC);
 
 CREATE INDEX IF NOT EXISTS idx_runs_scenario_id ON runs(scenario_id);
 CREATE INDEX IF NOT EXISTS idx_runs_status      ON runs(status);
 CREATE INDEX IF NOT EXISTS idx_runs_started_at  ON runs(started_at);
+CREATE INDEX IF NOT EXISTS idx_runs_started_at_id ON runs(started_at DESC, id DESC);

--- a/perf-backend/src/test/java/eottabom/perf/core/RunServiceTests.java
+++ b/perf-backend/src/test/java/eottabom/perf/core/RunServiceTests.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -102,6 +103,22 @@ class RunServiceTests {
 
 		// then
 		assertThat(result).hasSize(1);
+		verify(runRepository).findAfter(TestFixtures.FIXED_TIME, "r-1", 50);
+	}
+
+	@Test
+	void findAllUsesFallbackAfterIdWhenCursorIdMissing() {
+		// given
+		var scenario = TestFixtures.k6Scenario();
+		given(runRepository.findAfter(any(), any(), anyInt())).willReturn(List.of(TestFixtures.completedRun()));
+		given(scenarioService.findAllById(any())).willReturn(List.of(scenario));
+
+		// when
+		var result = runService.findAll(TestFixtures.FIXED_TIME, null, 50);
+
+		// then
+		assertThat(result).hasSize(1);
+		verify(runRepository).findAfter(eq(TestFixtures.FIXED_TIME), eq("~"), eq(50));
 	}
 
 	@Test

--- a/perf-backend/src/test/java/eottabom/perf/core/ScenarioServiceTests.java
+++ b/perf-backend/src/test/java/eottabom/perf/core/ScenarioServiceTests.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -68,6 +69,23 @@ class ScenarioServiceTests {
 		assertThat(result).hasSize(1)
 				.extracting(Scenario::name)
 				.containsExactly("Stress Test");
+		verify(scenarioRepository).findAfter(cursor, "id-2", 50);
+	}
+
+	@Test
+	void findAllUsesFallbackAfterIdWhenCursorIdMissing() {
+		// given
+		var cursor = TestFixtures.FIXED_TIME;
+		given(scenarioRepository.findAfter(any(), any(), anyInt())).willReturn(List.of(
+				TestFixtures.scenario("id-3", "Stress Test", Engine.K6)
+		));
+
+		// when
+		var result = scenarioService.findAll(cursor, "", 50);
+
+		// then
+		assertThat(result).hasSize(1);
+		verify(scenarioRepository).findAfter(eq(cursor), eq("~"), eq(50));
 	}
 
 	@Test


### PR DESCRIPTION
## 📝 작업 내용
- afterId 누락, 공백일 때 기본 커서로 정규화
- 커서 기반 정렬 최적화를 위한 복합 인덱스 추가
  - scenarios(created_at DESC, id DESC)
  - runs(started_at DESC, id DESC)


## 🔗 관련 이슈

- Closes #

