### PR TITLE
test: gatling-runner 핵심 플로우 유닛테스트 추가

### DIFF
--- a/gatling-runner/src/test/java/io/github/eottabom/gatling/core/SimulationAnnotationScannerTests.java
+++ b/gatling-runner/src/test/java/io/github/eottabom/gatling/core/SimulationAnnotationScannerTests.java
@@ -1,0 +1,142 @@
+package io.github.eottabom.gatling.core;
+
+import io.gatling.javaapi.core.OpenInjectionStep;
+import io.gatling.javaapi.core.ScenarioBuilder;
+import io.gatling.javaapi.http.HttpProtocolBuilder;
+import io.github.eottabom.gatling.annotation.Injection;
+import io.github.eottabom.gatling.annotation.LoadTest;
+import io.github.eottabom.gatling.annotation.Protocol;
+import io.github.eottabom.gatling.annotation.Scenario;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static io.gatling.javaapi.core.CoreDsl.constantUsersPerSec;
+import static io.gatling.javaapi.core.CoreDsl.scenario;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Fixture fields intentionally avoid io.gatling.javaapi.http.HttpDsl ({@code http(...)}):
+ * its static initializer calls into Gatling's Predef configuration, which is only set up
+ * when Gatling itself boots a Simulation. Outside of that, touching HttpDsl blows up the
+ * class forever in this JVM. HttpProtocolBuilder's public constructor and CoreDsl.scenario()
+ * don't have that dependency, so real Gatling types can still be scanned in isolation.
+ */
+class SimulationAnnotationScannerTests {
+
+	private final SimulationAnnotationScanner scanner = new SimulationAnnotationScanner();
+
+	@Test
+	void scansValidClassAndUsesClassNameWhenLoadTestNameIsBlank() throws ReflectiveOperationException {
+		var descriptor = scanner.scan(ValidScenario.class);
+
+		assertThat(descriptor.simulationName()).isEqualTo("ValidScenario");
+		assertThat(descriptor.scenarioName()).isEqualTo("Named Scenario");
+		assertThat(descriptor.protocol()).isNotNull();
+		assertThat(descriptor.scenario()).isNotNull();
+		assertThat(descriptor.injection()).hasSize(1);
+	}
+
+	@Test
+	void usesLoadTestNameWhenProvided() throws ReflectiveOperationException {
+		var descriptor = scanner.scan(NamedScenario.class);
+
+		assertThat(descriptor.simulationName()).isEqualTo("Custom Name");
+	}
+
+	@Test
+	void wrapsSingleInjectionStepIntoArray() throws ReflectiveOperationException {
+		var descriptor = scanner.scan(SingleInjectionScenario.class);
+
+		assertThat(descriptor.injection()).hasSize(1);
+	}
+
+	@Test
+	void throwsWhenProtocolFieldIsMissing() {
+		assertThatThrownBy(() -> scanner.scan(MissingProtocolScenario.class))
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessageContaining("Missing @Protocol field");
+	}
+
+	@Test
+	void throwsWhenScenarioFieldIsMissing() {
+		assertThatThrownBy(() -> scanner.scan(MissingScenarioScenario.class))
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessageContaining("Missing @Scenario field");
+	}
+
+	@Test
+	void throwsWhenInjectionFieldIsMissing() {
+		assertThatThrownBy(() -> scanner.scan(MissingInjectionScenario.class))
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessageContaining("Missing @Injection field");
+	}
+
+	private static HttpProtocolBuilder fakeProtocol() {
+		return new HttpProtocolBuilder(null);
+	}
+
+	@LoadTest
+	static class ValidScenario {
+		@Protocol
+		HttpProtocolBuilder protocol = fakeProtocol();
+
+		@Scenario
+		ScenarioBuilder scenario = scenario("Named Scenario");
+
+		@Injection
+		OpenInjectionStep[] injection = {constantUsersPerSec(1).during(Duration.ofSeconds(1))};
+	}
+
+	@LoadTest(name = "Custom Name")
+	static class NamedScenario {
+		@Protocol
+		HttpProtocolBuilder protocol = fakeProtocol();
+
+		@Scenario
+		ScenarioBuilder scenario = scenario("Any");
+
+		@Injection
+		OpenInjectionStep[] injection = {constantUsersPerSec(1).during(Duration.ofSeconds(1))};
+	}
+
+	@LoadTest
+	static class SingleInjectionScenario {
+		@Protocol
+		HttpProtocolBuilder protocol = fakeProtocol();
+
+		@Scenario
+		ScenarioBuilder scenario = scenario("Single Injection");
+
+		@Injection
+		OpenInjectionStep injection = constantUsersPerSec(1).during(Duration.ofSeconds(1));
+	}
+
+	@LoadTest
+	static class MissingProtocolScenario {
+		@Scenario
+		ScenarioBuilder scenario = scenario("Any");
+
+		@Injection
+		OpenInjectionStep[] injection = {constantUsersPerSec(1).during(Duration.ofSeconds(1))};
+	}
+
+	@LoadTest
+	static class MissingScenarioScenario {
+		@Protocol
+		HttpProtocolBuilder protocol = fakeProtocol();
+
+		@Injection
+		OpenInjectionStep[] injection = {constantUsersPerSec(1).during(Duration.ofSeconds(1))};
+	}
+
+	@LoadTest
+	static class MissingInjectionScenario {
+		@Protocol
+		HttpProtocolBuilder protocol = fakeProtocol();
+
+		@Scenario
+		ScenarioBuilder scenario = scenario("Any");
+	}
+}

--- a/gatling-runner/src/test/java/io/github/eottabom/gatling/core/SimulationAnnotationScannerTests.java
+++ b/gatling-runner/src/test/java/io/github/eottabom/gatling/core/SimulationAnnotationScannerTests.java
@@ -17,11 +17,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Fixture fields intentionally avoid io.gatling.javaapi.http.HttpDsl ({@code http(...)}):
- * its static initializer calls into Gatling's Predef configuration, which is only set up
- * when Gatling itself boots a Simulation. Outside of that, touching HttpDsl blows up the
- * class forever in this JVM. HttpProtocolBuilder's public constructor and CoreDsl.scenario()
- * don't have that dependency, so real Gatling types can still be scanned in isolation.
+ * 픽스처 필드는 io.gatling.javaapi.http.HttpDsl({@code http(...)}) 사용을 의도적으로 피한다.
+ * HttpDsl의 static 초기화 블록은 Gatling이 Simulation을 부트스트랩할 때만 채워지는 Predef 설정에
+ * 접근하는데, 그 밖의 상황에서 HttpDsl을 건드리면 해당 JVM에서 이후로 계속 초기화 실패한다.
+ * HttpProtocolBuilder의 public 생성자와 CoreDsl.scenario()는 이 의존성이 없어서
+ * 실제 Gatling 타입을 격리된 상태에서도 스캔할 수 있다.
  */
 class SimulationAnnotationScannerTests {
 

--- a/gatling-runner/src/test/java/io/github/eottabom/gatling/core/SimulationDescriptorTests.java
+++ b/gatling-runner/src/test/java/io/github/eottabom/gatling/core/SimulationDescriptorTests.java
@@ -31,4 +31,11 @@ class SimulationDescriptorTests {
 
 		assertThat(descriptor.injection()).isNull();
 	}
+
+	@Test
+	void distinguishesEmptyInjectionArrayFromNull() {
+		var descriptor = new SimulationDescriptor("sim", "scenario", null, null, new OpenInjectionStep[0]);
+
+		assertThat(descriptor.injection()).isNotNull().isEmpty();
+	}
 }

--- a/gatling-runner/src/test/java/io/github/eottabom/gatling/core/SimulationDescriptorTests.java
+++ b/gatling-runner/src/test/java/io/github/eottabom/gatling/core/SimulationDescriptorTests.java
@@ -1,0 +1,34 @@
+package io.github.eottabom.gatling.core;
+
+import io.gatling.javaapi.core.OpenInjectionStep;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static io.gatling.javaapi.core.CoreDsl.constantUsersPerSec;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SimulationDescriptorTests {
+
+	@Test
+	void defensivelyCopiesInjectionArrayOnConstructionAndAccess() {
+		var original = new OpenInjectionStep[]{constantUsersPerSec(1).during(Duration.ofSeconds(1))};
+
+		var descriptor = new SimulationDescriptor("sim", "scenario", null, null, original);
+		original[0] = null;
+
+		assertThat(descriptor.injection()[0]).isNotNull();
+
+		var firstRead = descriptor.injection();
+		firstRead[0] = null;
+
+		assertThat(descriptor.injection()[0]).isNotNull();
+	}
+
+	@Test
+	void allowsNullInjection() {
+		var descriptor = new SimulationDescriptor("sim", "scenario", null, null, null);
+
+		assertThat(descriptor.injection()).isNull();
+	}
+}

--- a/gatling-runner/src/test/java/io/github/eottabom/gatling/runner/RuntimeCompilerTests.java
+++ b/gatling-runner/src/test/java/io/github/eottabom/gatling/runner/RuntimeCompilerTests.java
@@ -102,6 +102,18 @@ class RuntimeCompilerTests {
 				.hasMessageContaining("Compilation failed");
 	}
 
+	@Test
+	void throwsWhenPublicClassNameDoesNotMatchFileName() throws IOException {
+		// javac는 public 클래스가 동일한 이름의 파일에 선언되기를 요구한다.
+		// parseFQCN은 소스 텍스트만 읽으므로, 이 불일치는 컴파일 시점에야 드러난다.
+		var sourceFile = writeSource("Wrong", "public class Actual {}\n");
+
+		assertThatThrownBy(() -> RuntimeCompiler.compile(sourceFile))
+				.isInstanceOf(RuntimeException.class)
+				.hasMessageContaining("Compilation failed")
+				.hasMessageContaining("should be declared in a file named Actual.java");
+	}
+
 	private Path writeSource(String fileName, String content) throws IOException {
 		tempDir = Files.createTempDirectory("runtime-compiler-test-");
 		var sourceFile = tempDir.resolve(fileName + ".java");

--- a/gatling-runner/src/test/java/io/github/eottabom/gatling/runner/RuntimeCompilerTests.java
+++ b/gatling-runner/src/test/java/io/github/eottabom/gatling/runner/RuntimeCompilerTests.java
@@ -17,10 +17,15 @@ class RuntimeCompilerTests {
 
 	@AfterEach
 	void cleanup() throws IOException {
-		if (tempDir != null && Files.exists(tempDir)) {
-			try (var paths = Files.walk(tempDir)) {
-				paths.sorted(Comparator.reverseOrder()).forEach(p -> p.toFile().delete());
-			}
+		if (tempDir == null || !Files.exists(tempDir)) {
+			return;
+		}
+		Path[] pathsToDelete;
+		try (var paths = Files.walk(tempDir)) {
+			pathsToDelete = paths.sorted(Comparator.reverseOrder()).toArray(Path[]::new);
+		}
+		for (Path path : pathsToDelete) {
+			Files.delete(path);
 		}
 	}
 

--- a/gatling-runner/src/test/java/io/github/eottabom/gatling/runner/RuntimeCompilerTests.java
+++ b/gatling-runner/src/test/java/io/github/eottabom/gatling/runner/RuntimeCompilerTests.java
@@ -1,0 +1,111 @@
+package io.github.eottabom.gatling.runner;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RuntimeCompilerTests {
+
+	private Path tempDir;
+
+	@AfterEach
+	void cleanup() throws IOException {
+		if (tempDir != null && Files.exists(tempDir)) {
+			try (var paths = Files.walk(tempDir)) {
+				paths.sorted(Comparator.reverseOrder()).forEach(p -> p.toFile().delete());
+			}
+		}
+	}
+
+	@Test
+	void parsesPackageDeclaration() {
+		var source = "package io.github.eottabom.gatling.simulations;\n\npublic class Foo {}\n";
+
+		assertThat(RuntimeCompiler.parsePackage(source)).isEqualTo("io.github.eottabom.gatling.simulations");
+	}
+
+	@Test
+	void returnsEmptyStringWhenPackageDeclarationIsAbsent() {
+		var source = "public class Foo {}\n";
+
+		assertThat(RuntimeCompiler.parsePackage(source)).isEmpty();
+	}
+
+	@Test
+	void parsesPublicClassName() {
+		var source = "public class MyScenario {}\n";
+
+		assertThat(RuntimeCompiler.parseClassName(source)).isEqualTo("MyScenario");
+	}
+
+	@Test
+	void returnsNullWhenNoPublicClassDeclarationExists() {
+		var source = "class MyScenario {}\n";
+
+		assertThat(RuntimeCompiler.parseClassName(source)).isNull();
+	}
+
+	@Test
+	void compilesSourceFileWithoutPackageAndLoadsClass() throws Exception {
+		var source = """
+				public class CompilerTestScenario {
+				    public static String greet() {
+				        return "hello";
+				    }
+				}
+				""";
+		var sourceFile = writeSource("CompilerTestScenario", source);
+
+		var clazz = RuntimeCompiler.compile(sourceFile);
+
+		assertThat(clazz.getName()).isEqualTo("CompilerTestScenario");
+		assertThat(clazz.getMethod("greet").invoke(null)).isEqualTo("hello");
+	}
+
+	@Test
+	void compilesSourceFileWithPackageDeclaration() throws Exception {
+		var source = """
+				package io.github.eottabom.gatling.compiled;
+
+				public class PackagedTestScenario {
+				}
+				""";
+		var sourceFile = writeSource("PackagedTestScenario", source);
+
+		var clazz = RuntimeCompiler.compile(sourceFile);
+
+		assertThat(clazz.getName()).isEqualTo("io.github.eottabom.gatling.compiled.PackagedTestScenario");
+	}
+
+	@Test
+	void throwsWhenSourceHasNoPublicClassDeclaration() throws IOException {
+		var sourceFile = writeSource("NoPublicClass", "class NoPublicClass {}\n");
+
+		assertThatThrownBy(() -> RuntimeCompiler.compile(sourceFile))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("Could not find public class declaration");
+	}
+
+	@Test
+	void throwsWithDiagnosticsWhenSourceFailsToCompile() throws IOException {
+		var sourceFile = writeSource("BrokenScenario", "public class BrokenScenario { this is not valid java }\n");
+
+		assertThatThrownBy(() -> RuntimeCompiler.compile(sourceFile))
+				.isInstanceOf(RuntimeException.class)
+				.hasMessageContaining("Compilation failed");
+	}
+
+	private Path writeSource(String fileName, String content) throws IOException {
+		tempDir = Files.createTempDirectory("runtime-compiler-test-");
+		var sourceFile = tempDir.resolve(fileName + ".java");
+		Files.writeString(sourceFile, content);
+		return sourceFile;
+	}
+}


### PR DESCRIPTION
## Summary
- `SimulationAnnotationScanner`: `@Protocol`/`@Scenario`/`@Injection` 필드 스캔, `@LoadTest` 이름 기본값/커스텀 처리, 단일 `OpenInjectionStep` 배열 래핑, 각 필드 누락 시 `IllegalStateException` 검증
- `SimulationDescriptor`: injection 배열 방어적 복사(생성 시 / 접근 시) 검증
- `RuntimeCompiler`: 패키지/클래스명 파싱, 외부 `.java` 소스 런타임 컴파일 및 클래스 로드(패키지 유무 모두), public class 선언 누락/컴파일 실패 시 예외 검증

## Note
`HttpDsl`(`http(...)`) static init이 Gatling 엔진이 Simulation을 부트스트랩할 때만 설정되는 Predef 설정에 의존해서, 엔진 밖에서 건드리면 `IllegalStateException: Simulations can't be instantiated directly but only by Gatling.`으로 죽습니다(한 번 죽으면 같은 JVM에서 계속 `NoClassDefFoundError`). 스캐너 테스트 픽스처는 이를 우회하기 위해 `HttpProtocolBuilder`의 public 생성자와 `CoreDsl.scenario(...)`만 사용했습니다.

기존 `GatlingPrometheusMetricsTests`(Testcontainers 기반)는 로컬 샌드박스에 Docker가 없어 실행하지 못했지만 이번 변경과 무관합니다.

Closes #5

## Test plan
- [x] `./gradlew test --tests "io.github.eottabom.gatling.core.*" --tests "io.github.eottabom.gatling.runner.*"` — 17개 신규 테스트 모두 통과
- [ ] CI에서 `GatlingPrometheusMetricsTests`(Docker 필요) 포함 전체 스위트 확인