### PR TITLE
ci: PR 생성 시 codex/claude 자동 코드리뷰 워크플로우 추가

### DIFF
--- a/.github/scripts/claude-review-run.sh
+++ b/.github/scripts/claude-review-run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export PATH="/Users/yukeun/.local/bin:$PATH"
+export PATH="$HOME/.local/bin:$PATH"
 
 REVIEW_FILE="/tmp/claude-review-${PR_NUMBER}.json"
 

--- a/.github/scripts/claude-review-run.sh
+++ b/.github/scripts/claude-review-run.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export PATH="/Users/yukeun/.local/bin:$PATH"
+
+REVIEW_FILE="/tmp/claude-review-${PR_NUMBER}.json"
+
+PROMPT_FILE=$(mktemp /tmp/claude-review-prompt.XXXXXX.txt)
+trap 'rm -f "$PROMPT_FILE"' EXIT
+
+cat > "$PROMPT_FILE" <<PROMPT_EOF
+You are reviewing PR #${PR_NUMBER} in the sandbox-load-test repository.
+
+Steps:
+1. Read ALL CLAUDE.md/AGENTS.md files to understand project conventions.
+2. Run: git diff origin/${BASE_REF}...HEAD --name-only  (get changed files)
+3. Run: git diff origin/${BASE_REF}...HEAD  (get the full diff with line numbers)
+4. Read the changed files to understand context.
+5. Write a thorough code review in Korean.
+
+6. Write the review to ${REVIEW_FILE} in this exact JSON format.
+   The 'body' field must use this exact markdown structure:
+
+{
+  "body": "## 🤖 eottabom-claude-review\n\n### 📊 종합 평가\n\n| 항목 | 평가 |\n|------|------|\n| ✅ Correctness | <가능 / 불가 + 한 줄 이유> |\n| 🔁 Regression Risk | <🔴 매우 높음 / 🟡 보통 / 🟢 낮음 + 한 줄 이유> |\n| ⚠️ Risky Changes | <있음: 내용 요약 / 없음> |\n| 🧪 Missing Tests | <있음: 내용 요약 / 없음> |\n\n### 📝 상세 리뷰\n\n<상세 리뷰 내용을 마크다운으로 작성. 파일명, 라인, 근거를 구체적으로>",
+  "event": "COMMENT",
+  "comments": [
+    {
+      "path": "relative/path/to/file.java",
+      "line": <line number in the new version of the file>,
+      "side": "RIGHT",
+      "body": "<specific inline comment in Korean>"
+    }
+  ]
+}
+
+7. Post the review:
+   gh api /repos/eottabom/sandbox-load-test/pulls/${PR_NUMBER}/reviews --method POST --input ${REVIEW_FILE}
+
+Rules:
+- Only add inline comments on lines that exist in the diff (added or changed lines on the RIGHT side).
+- The 'line' must be the actual line number in the current file, not the diff position.
+- If there are no specific inline findings, use an empty array for 'comments'.
+- If there are no findings at all, still post a summary saying so.
+- Write everything in Korean.
+PROMPT_EOF
+
+claude --dangerously-skip-permissions --verbose --output-format stream-json < "$PROMPT_FILE"

--- a/.github/scripts/codex-review-run.sh
+++ b/.github/scripts/codex-review-run.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export PATH="/Users/yukeun/.local/bin:$PATH"
+export PATH="$HOME/.local/bin:$PATH"
+: "${RUNNER_WORKDIR:?RUNNER_WORKDIR env var must be set}"
 
 REVIEW_FILE="/tmp/codex-review-${PR_NUMBER}.json"
 
@@ -45,6 +46,6 @@ Rules:
 PROMPT_EOF
 
 codex exec \
-  -C "/Users/yukeun/workspace/sandbox-load-test" \
+  -C "$RUNNER_WORKDIR" \
   --dangerously-bypass-approvals-and-sandbox \
   - < "$PROMPT_FILE"

--- a/.github/scripts/codex-review-run.sh
+++ b/.github/scripts/codex-review-run.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export PATH="/Users/yukeun/.local/bin:$PATH"
+
+REVIEW_FILE="/tmp/codex-review-${PR_NUMBER}.json"
+
+PROMPT_FILE=$(mktemp /tmp/codex-review-prompt.XXXXXX.txt)
+trap 'rm -f "$PROMPT_FILE"' EXIT
+
+cat > "$PROMPT_FILE" <<PROMPT_EOF
+You are reviewing PR #${PR_NUMBER} in the sandbox-load-test repository.
+
+Steps:
+1. Read all AGENTS.md/CLAUDE.md files to understand project conventions.
+2. Run: git diff origin/${BASE_REF}...HEAD --name-only  (get changed files)
+3. Run: git diff origin/${BASE_REF}...HEAD  (get the full diff with line numbers)
+4. Read the changed files to understand context.
+5. Write a thorough code review in Korean.
+
+6. Write the review to ${REVIEW_FILE} in this exact JSON format.
+   The 'body' field must use this exact markdown structure:
+{
+  "body": "## 🤖 eottabom-codex-review\n\n### 📊 종합 평가\n\n| 항목 | 평가 |\n|------|------|\n| ✅ Correctness | <가능 / 불가 + 한 줄 이유> |\n| 🔁 Regression Risk | <🔴 매우 높음 / 🟡 보통 / 🟢 낮음 + 한 줄 이유> |\n| ⚠️ Risky Changes | <있음: 내용 요약 / 없음> |\n| 🧪 Missing Tests | <있음: 내용 요약 / 없음> |\n\n### 📝 상세 리뷰\n\n<상세 리뷰 내용을 마크다운으로 작성. 파일명, 라인, 근거를 구체적으로>",
+  "event": "COMMENT",
+  "comments": [
+    {
+      "path": "relative/path/to/file.java",
+      "line": <line number in the new version of the file>,
+      "side": "RIGHT",
+      "body": "<specific inline comment in Korean>"
+    }
+  ]
+}
+
+7. Post the review:
+   gh api /repos/eottabom/sandbox-load-test/pulls/${PR_NUMBER}/reviews --method POST --input ${REVIEW_FILE}
+
+Rules:
+- Only add inline comments on lines that exist in the diff (added or changed lines on the RIGHT side).
+- The 'line' must be the actual line number in the current file, not the diff position.
+- If there are no specific inline findings, use an empty array for 'comments'.
+- If there are no findings at all, still post a summary saying so.
+- Write everything in Korean.
+PROMPT_EOF
+
+codex exec \
+  -C "/Users/yukeun/workspace/sandbox-load-test" \
+  --dangerously-bypass-approvals-and-sandbox \
+  - < "$PROMPT_FILE"

--- a/.github/workflows/pr-auto-review.yml
+++ b/.github/workflows/pr-auto-review.yml
@@ -1,0 +1,103 @@
+name: PR Auto Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  claude-review:
+    if: github.event.pull_request.draft == false
+    timeout-minutes: 30
+    concurrency:
+      group: claude-review-pr-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    runs-on: [self-hosted, macOS, X64]
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      BASE_REF: ${{ github.event.pull_request.base.ref }}
+
+    defaults:
+      run:
+        working-directory: /Users/yukeun/workspace/sandbox-load-test
+
+    steps:
+      - name: Checkout PR branch
+        run: |
+          git remote set-url origin https://x-access-token:${{ secrets.BOT_TOKEN }}@github.com/eottabom/sandbox-load-test.git
+          git fetch origin
+          git checkout ${{ github.event.pull_request.head.ref }} 2>/dev/null || git checkout -b ${{ github.event.pull_request.head.ref }} origin/${{ github.event.pull_request.head.ref }}
+          git reset --hard origin/${{ github.event.pull_request.head.ref }}
+
+      - name: Check Claude login status
+        id: claude_auth
+        env:
+          HOME: /Users/yukeun
+          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+        run: |
+          export PATH="/Users/yukeun/.local/bin:$PATH"
+          if claude auth status 2>/dev/null | jq -e '.loggedIn == true' >/dev/null; then
+            echo "logged_in=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "logged_in=false" >> "$GITHUB_OUTPUT"
+            gh pr comment "$PR_NUMBER" --repo eottabom/sandbox-load-test --body "⚠️ **eottabom-bot** self-hosted 러너의 \`claude\` CLI 로그인 세션이 만료되어 자동 리뷰를 실행할 수 없습니다. 러너 머신에서 \`claude /login\`으로 재로그인해 주세요."
+          fi
+
+      - name: Run Claude review
+        if: steps.claude_auth.outputs.logged_in == 'true'
+        env:
+          HOME: /Users/yukeun
+          CI: ""
+          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+        run: |
+          unset CI
+          unset GITHUB_ACTIONS
+          unset GITHUB_TOKEN
+          bash /Users/yukeun/workspace/sandbox-load-test/.github/scripts/claude-review-run.sh 2>&1 | \
+            jq --unbuffered -r '
+              if .type == "assistant" then
+                (.message.content // [])[] |
+                if .type == "text" then .text
+                elif .type == "tool_use" then "[tool:\(.name)] \(.input | tostring | .[0:200])"
+                else empty end
+              elif .type == "tool_result" then
+                "  → \((.content // [])[] | select(.type == "text") | .text | .[0:300])"
+              elif .type == "result" then
+                "\n=== \(.subtype) ==="
+              else empty end
+            ' 2>/dev/null || true
+
+  codex-review:
+    if: github.event.pull_request.draft == false
+    timeout-minutes: 30
+    concurrency:
+      group: codex-review-pr-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    runs-on: [self-hosted, macOS, X64]
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      BASE_REF: ${{ github.event.pull_request.base.ref }}
+
+    defaults:
+      run:
+        working-directory: /Users/yukeun/workspace/sandbox-load-test
+
+    steps:
+      - name: Checkout PR branch
+        run: |
+          git remote set-url origin https://x-access-token:${{ secrets.BOT_TOKEN }}@github.com/eottabom/sandbox-load-test.git
+          git fetch origin
+          git checkout ${{ github.event.pull_request.head.ref }} 2>/dev/null || git checkout -b ${{ github.event.pull_request.head.ref }} origin/${{ github.event.pull_request.head.ref }}
+          git reset --hard origin/${{ github.event.pull_request.head.ref }}
+
+      - name: Run Codex review
+        env:
+          HOME: /Users/yukeun
+          CI: ""
+          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+        run: |
+          unset CI
+          bash /Users/yukeun/workspace/sandbox-load-test/.github/scripts/codex-review-run.sh

--- a/.github/workflows/pr-auto-review.yml
+++ b/.github/workflows/pr-auto-review.yml
@@ -10,7 +10,9 @@ permissions:
 
 jobs:
   claude-review:
-    if: github.event.pull_request.draft == false
+    if: |
+      github.event.pull_request.draft == false &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
     timeout-minutes: 30
     concurrency:
       group: claude-review-pr-${{ github.event.pull_request.number }}
@@ -25,12 +27,16 @@ jobs:
         working-directory: ${{ vars.RUNNER_WORKDIR }}
 
     steps:
-      - name: Checkout PR branch
+      - name: Checkout PR head
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/eottabom/sandbox-load-test.git
-          git fetch origin
-          git checkout ${{ github.event.pull_request.head.ref }} 2>/dev/null || git checkout -b ${{ github.event.pull_request.head.ref }} origin/${{ github.event.pull_request.head.ref }}
-          git reset --hard origin/${{ github.event.pull_request.head.ref }}
+          git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/eottabom/sandbox-load-test.git"
+          git fetch origin "refs/pull/${PR_NUMBER}/head"
+          git checkout --detach FETCH_HEAD
+          git reset --hard FETCH_HEAD
+          test "$(git rev-parse HEAD)" = "$HEAD_SHA"
+          git remote set-url origin "https://github.com/eottabom/sandbox-load-test.git"
 
       - name: Check Claude login status
         id: claude_auth
@@ -56,6 +62,8 @@ jobs:
           unset CI
           unset GITHUB_ACTIONS
           unset GITHUB_TOKEN
+          set +e
+          set -o pipefail
           bash "${{ vars.RUNNER_WORKDIR }}/.github/scripts/claude-review-run.sh" 2>&1 | \
             jq --unbuffered -r '
               if .type == "assistant" then
@@ -68,10 +76,15 @@ jobs:
               elif .type == "result" then
                 "\n=== \(.subtype) ==="
               else empty end
-            ' 2>/dev/null || true
+            ' 2>/dev/null
+          rc="${PIPESTATUS[0]}"
+          set -e
+          exit "$rc"
 
   codex-review:
-    if: github.event.pull_request.draft == false
+    if: |
+      github.event.pull_request.draft == false &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
     timeout-minutes: 30
     concurrency:
       group: codex-review-pr-${{ github.event.pull_request.number }}
@@ -86,14 +99,33 @@ jobs:
         working-directory: ${{ vars.RUNNER_WORKDIR }}
 
     steps:
-      - name: Checkout PR branch
+      - name: Checkout PR head
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/eottabom/sandbox-load-test.git
-          git fetch origin
-          git checkout ${{ github.event.pull_request.head.ref }} 2>/dev/null || git checkout -b ${{ github.event.pull_request.head.ref }} origin/${{ github.event.pull_request.head.ref }}
-          git reset --hard origin/${{ github.event.pull_request.head.ref }}
+          git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/eottabom/sandbox-load-test.git"
+          git fetch origin "refs/pull/${PR_NUMBER}/head"
+          git checkout --detach FETCH_HEAD
+          git reset --hard FETCH_HEAD
+          test "$(git rev-parse HEAD)" = "$HEAD_SHA"
+          git remote set-url origin "https://github.com/eottabom/sandbox-load-test.git"
+
+      - name: Check Codex login status
+        id: codex_auth
+        env:
+          HOME: ${{ vars.RUNNER_HOME }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          if codex login status 2>/dev/null | grep -qi "logged in"; then
+            echo "logged_in=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "logged_in=false" >> "$GITHUB_OUTPUT"
+            gh pr comment "$PR_NUMBER" --repo eottabom/sandbox-load-test --body "⚠️ **eottabom-review-bot** self-hosted 러너의 \`codex\` CLI 로그인 세션이 만료되어 자동 리뷰를 실행할 수 없습니다. 러너 머신에서 \`codex login\`으로 재로그인해 주세요."
+          fi
 
       - name: Run Codex review
+        if: steps.codex_auth.outputs.logged_in == 'true'
         env:
           HOME: ${{ vars.RUNNER_HOME }}
           CI: ""

--- a/.github/workflows/pr-auto-review.yml
+++ b/.github/workflows/pr-auto-review.yml
@@ -1,4 +1,4 @@
-name: PR Auto Review
+name: 🤖 PR Auto Review
 
 on:
   pull_request:
@@ -22,12 +22,12 @@ jobs:
 
     defaults:
       run:
-        working-directory: /Users/yukeun/workspace/sandbox-load-test
+        working-directory: ${{ vars.RUNNER_WORKDIR }}
 
     steps:
       - name: Checkout PR branch
         run: |
-          git remote set-url origin https://x-access-token:${{ secrets.BOT_TOKEN }}@github.com/eottabom/sandbox-load-test.git
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/eottabom/sandbox-load-test.git
           git fetch origin
           git checkout ${{ github.event.pull_request.head.ref }} 2>/dev/null || git checkout -b ${{ github.event.pull_request.head.ref }} origin/${{ github.event.pull_request.head.ref }}
           git reset --hard origin/${{ github.event.pull_request.head.ref }}
@@ -35,28 +35,28 @@ jobs:
       - name: Check Claude login status
         id: claude_auth
         env:
-          HOME: /Users/yukeun
-          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          HOME: ${{ vars.RUNNER_HOME }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          export PATH="/Users/yukeun/.local/bin:$PATH"
+          export PATH="$HOME/.local/bin:$PATH"
           if claude auth status 2>/dev/null | jq -e '.loggedIn == true' >/dev/null; then
             echo "logged_in=true" >> "$GITHUB_OUTPUT"
           else
             echo "logged_in=false" >> "$GITHUB_OUTPUT"
-            gh pr comment "$PR_NUMBER" --repo eottabom/sandbox-load-test --body "⚠️ **eottabom-bot** self-hosted 러너의 \`claude\` CLI 로그인 세션이 만료되어 자동 리뷰를 실행할 수 없습니다. 러너 머신에서 \`claude /login\`으로 재로그인해 주세요."
+            gh pr comment "$PR_NUMBER" --repo eottabom/sandbox-load-test --body "⚠️ **eottabom-review-bot** self-hosted 러너의 \`claude\` CLI 로그인 세션이 만료되어 자동 리뷰를 실행할 수 없습니다. 러너 머신에서 \`claude /login\`으로 재로그인해 주세요."
           fi
 
       - name: Run Claude review
         if: steps.claude_auth.outputs.logged_in == 'true'
         env:
-          HOME: /Users/yukeun
+          HOME: ${{ vars.RUNNER_HOME }}
           CI: ""
-          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           unset CI
           unset GITHUB_ACTIONS
           unset GITHUB_TOKEN
-          bash /Users/yukeun/workspace/sandbox-load-test/.github/scripts/claude-review-run.sh 2>&1 | \
+          bash "${{ vars.RUNNER_WORKDIR }}/.github/scripts/claude-review-run.sh" 2>&1 | \
             jq --unbuffered -r '
               if .type == "assistant" then
                 (.message.content // [])[] |
@@ -83,21 +83,22 @@ jobs:
 
     defaults:
       run:
-        working-directory: /Users/yukeun/workspace/sandbox-load-test
+        working-directory: ${{ vars.RUNNER_WORKDIR }}
 
     steps:
       - name: Checkout PR branch
         run: |
-          git remote set-url origin https://x-access-token:${{ secrets.BOT_TOKEN }}@github.com/eottabom/sandbox-load-test.git
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/eottabom/sandbox-load-test.git
           git fetch origin
           git checkout ${{ github.event.pull_request.head.ref }} 2>/dev/null || git checkout -b ${{ github.event.pull_request.head.ref }} origin/${{ github.event.pull_request.head.ref }}
           git reset --hard origin/${{ github.event.pull_request.head.ref }}
 
       - name: Run Codex review
         env:
-          HOME: /Users/yukeun
+          HOME: ${{ vars.RUNNER_HOME }}
           CI: ""
-          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUNNER_WORKDIR: ${{ vars.RUNNER_WORKDIR }}
         run: |
           unset CI
-          bash /Users/yukeun/workspace/sandbox-load-test/.github/scripts/codex-review-run.sh
+          bash "${{ vars.RUNNER_WORKDIR }}/.github/scripts/codex-review-run.sh"

--- a/.github/workflows/pr-mention-review.yml
+++ b/.github/workflows/pr-mention-review.yml
@@ -13,7 +13,8 @@ jobs:
     if: |
       contains(github.event.comment.body, '@eottabom-review-bot') &&
       github.event.issue.pull_request != null &&
-      github.event.comment.user.type != 'Bot'
+      github.event.comment.user.type != 'Bot' &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     timeout-minutes: 30
     concurrency:
       group: claude-review-pr-${{ github.event.issue.number }}
@@ -50,15 +51,19 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.payload.issue.number
             });
-            core.setOutput('branch', pr.head.ref);
             core.setOutput('base_ref', pr.base.ref);
+            core.setOutput('head_sha', pr.head.sha);
 
-      - name: Checkout PR branch
+      - name: Checkout PR head
+        env:
+          HEAD_SHA: ${{ steps.pr_info.outputs.head_sha }}
         run: |
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/eottabom/sandbox-load-test.git
-          git fetch origin
-          git checkout ${{ steps.pr_info.outputs.branch }} 2>/dev/null || git checkout -b ${{ steps.pr_info.outputs.branch }} origin/${{ steps.pr_info.outputs.branch }}
-          git reset --hard origin/${{ steps.pr_info.outputs.branch }}
+          git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/eottabom/sandbox-load-test.git"
+          git fetch origin "refs/pull/${PR_NUMBER}/head"
+          git checkout --detach FETCH_HEAD
+          git reset --hard FETCH_HEAD
+          test "$(git rev-parse HEAD)" = "$HEAD_SHA"
+          git remote set-url origin "https://github.com/eottabom/sandbox-load-test.git"
 
       - name: Check Claude login status
         id: claude_auth
@@ -85,6 +90,7 @@ jobs:
           unset CI
           unset GITHUB_ACTIONS
           unset GITHUB_TOKEN
+          set +e
           bash "${{ vars.RUNNER_WORKDIR }}/.github/scripts/claude-review-run.sh" 2>&1 | \
             jq --unbuffered -r '
               if .type == "assistant" then
@@ -97,13 +103,17 @@ jobs:
               elif .type == "result" then
                 "\n=== \(.subtype) ==="
               else empty end
-            ' 2>/dev/null || true
+            ' 2>/dev/null
+          rc="${PIPESTATUS[0]}"
+          set -e
+          exit "$rc"
 
   codex-review:
     if: |
       contains(github.event.comment.body, '@eottabom-review-bot') &&
       github.event.issue.pull_request != null &&
-      github.event.comment.user.type != 'Bot'
+      github.event.comment.user.type != 'Bot' &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     timeout-minutes: 30
     concurrency:
       group: codex-review-pr-${{ github.event.issue.number }}
@@ -140,17 +150,36 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.payload.issue.number
             });
-            core.setOutput('branch', pr.head.ref);
             core.setOutput('base_ref', pr.base.ref);
+            core.setOutput('head_sha', pr.head.sha);
 
-      - name: Checkout PR branch
+      - name: Checkout PR head
+        env:
+          HEAD_SHA: ${{ steps.pr_info.outputs.head_sha }}
         run: |
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/eottabom/sandbox-load-test.git
-          git fetch origin
-          git checkout ${{ steps.pr_info.outputs.branch }} 2>/dev/null || git checkout -b ${{ steps.pr_info.outputs.branch }} origin/${{ steps.pr_info.outputs.branch }}
-          git reset --hard origin/${{ steps.pr_info.outputs.branch }}
+          git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/eottabom/sandbox-load-test.git"
+          git fetch origin "refs/pull/${PR_NUMBER}/head"
+          git checkout --detach FETCH_HEAD
+          git reset --hard FETCH_HEAD
+          test "$(git rev-parse HEAD)" = "$HEAD_SHA"
+          git remote set-url origin "https://github.com/eottabom/sandbox-load-test.git"
+
+      - name: Check Codex login status
+        id: codex_auth
+        env:
+          HOME: ${{ vars.RUNNER_HOME }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          if codex login status 2>/dev/null | grep -qi "logged in"; then
+            echo "logged_in=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "logged_in=false" >> "$GITHUB_OUTPUT"
+            gh pr comment "$PR_NUMBER" --repo eottabom/sandbox-load-test --body "⚠️ **eottabom-review-bot** self-hosted 러너의 \`codex\` CLI 로그인 세션이 만료되어 재리뷰를 실행할 수 없습니다. 러너 머신에서 \`codex login\`으로 재로그인해 주세요."
+          fi
 
       - name: Run Codex review
+        if: steps.codex_auth.outputs.logged_in == 'true'
         env:
           HOME: ${{ vars.RUNNER_HOME }}
           CI: ""

--- a/.github/workflows/pr-mention-review.yml
+++ b/.github/workflows/pr-mention-review.yml
@@ -1,0 +1,162 @@
+name: 💬 PR Mention Re-review
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  claude-review:
+    if: |
+      contains(github.event.comment.body, '@eottabom-review-bot') &&
+      github.event.issue.pull_request != null &&
+      github.event.comment.user.type != 'Bot'
+    timeout-minutes: 30
+    concurrency:
+      group: claude-review-pr-${{ github.event.issue.number }}
+      cancel-in-progress: true
+    runs-on: [self-hosted, macOS, X64]
+    env:
+      PR_NUMBER: ${{ github.event.issue.number }}
+
+    defaults:
+      run:
+        working-directory: ${{ vars.RUNNER_WORKDIR }}
+
+    steps:
+      - name: React with eyes emoji
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes'
+            });
+
+      - name: Get PR info
+        id: pr_info
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.issue.number
+            });
+            core.setOutput('branch', pr.head.ref);
+            core.setOutput('base_ref', pr.base.ref);
+
+      - name: Checkout PR branch
+        run: |
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/eottabom/sandbox-load-test.git
+          git fetch origin
+          git checkout ${{ steps.pr_info.outputs.branch }} 2>/dev/null || git checkout -b ${{ steps.pr_info.outputs.branch }} origin/${{ steps.pr_info.outputs.branch }}
+          git reset --hard origin/${{ steps.pr_info.outputs.branch }}
+
+      - name: Check Claude login status
+        id: claude_auth
+        env:
+          HOME: ${{ vars.RUNNER_HOME }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          if claude auth status 2>/dev/null | jq -e '.loggedIn == true' >/dev/null; then
+            echo "logged_in=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "logged_in=false" >> "$GITHUB_OUTPUT"
+            gh pr comment "$PR_NUMBER" --repo eottabom/sandbox-load-test --body "⚠️ **eottabom-review-bot** self-hosted 러너의 \`claude\` CLI 로그인 세션이 만료되어 재리뷰를 실행할 수 없습니다. 러너 머신에서 \`claude /login\`으로 재로그인해 주세요."
+          fi
+
+      - name: Run Claude review
+        if: steps.claude_auth.outputs.logged_in == 'true'
+        env:
+          HOME: ${{ vars.RUNNER_HOME }}
+          CI: ""
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_REF: ${{ steps.pr_info.outputs.base_ref }}
+        run: |
+          unset CI
+          unset GITHUB_ACTIONS
+          unset GITHUB_TOKEN
+          bash "${{ vars.RUNNER_WORKDIR }}/.github/scripts/claude-review-run.sh" 2>&1 | \
+            jq --unbuffered -r '
+              if .type == "assistant" then
+                (.message.content // [])[] |
+                if .type == "text" then .text
+                elif .type == "tool_use" then "[tool:\(.name)] \(.input | tostring | .[0:200])"
+                else empty end
+              elif .type == "tool_result" then
+                "  → \((.content // [])[] | select(.type == "text") | .text | .[0:300])"
+              elif .type == "result" then
+                "\n=== \(.subtype) ==="
+              else empty end
+            ' 2>/dev/null || true
+
+  codex-review:
+    if: |
+      contains(github.event.comment.body, '@eottabom-review-bot') &&
+      github.event.issue.pull_request != null &&
+      github.event.comment.user.type != 'Bot'
+    timeout-minutes: 30
+    concurrency:
+      group: codex-review-pr-${{ github.event.issue.number }}
+      cancel-in-progress: true
+    runs-on: [self-hosted, macOS, X64]
+    env:
+      PR_NUMBER: ${{ github.event.issue.number }}
+
+    defaults:
+      run:
+        working-directory: ${{ vars.RUNNER_WORKDIR }}
+
+    steps:
+      - name: React with eyes emoji
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes'
+            });
+
+      - name: Get PR info
+        id: pr_info
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.issue.number
+            });
+            core.setOutput('branch', pr.head.ref);
+            core.setOutput('base_ref', pr.base.ref);
+
+      - name: Checkout PR branch
+        run: |
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/eottabom/sandbox-load-test.git
+          git fetch origin
+          git checkout ${{ steps.pr_info.outputs.branch }} 2>/dev/null || git checkout -b ${{ steps.pr_info.outputs.branch }} origin/${{ steps.pr_info.outputs.branch }}
+          git reset --hard origin/${{ steps.pr_info.outputs.branch }}
+
+      - name: Run Codex review
+        env:
+          HOME: ${{ vars.RUNNER_HOME }}
+          CI: ""
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_REF: ${{ steps.pr_info.outputs.base_ref }}
+          RUNNER_WORKDIR: ${{ vars.RUNNER_WORKDIR }}
+        run: |
+          unset CI
+          bash "${{ vars.RUNNER_WORKDIR }}/.github/scripts/codex-review-run.sh"


### PR DESCRIPTION
## Summary
- `pull_request: [opened, ready_for_review]` 시 `claude-review`/`codex-review` 잡을 병렬로 실행
- PR 코멘트에 `@eottabom-review-bot`을 멘션하면 같은 두 잡을 다시 실행 (`pr-mention-review.yml`)
- 두 잡 모두 `pulls/{pr}/reviews` API로 정식 GitHub 리뷰(종합 평가 표 + 인라인 코멘트)를 남김
- 별도 봇 계정/PAT 없이 기본 `GITHUB_TOKEN`으로 동작 (코멘트 작성자는 `github-actions[bot]`, 본문 헤더에 `eottabom-review-bot` 브랜딩)
- 러너 작업 디렉터리/HOME은 워크플로우에 하드코딩하지 않고 리포지토리 Variable(`vars.RUNNER_WORKDIR`, `vars.RUNNER_HOME`)로 분리 — public 저장소에 로컬 경로가 노출되지 않도록 함 (이미 `gh variable set`으로 등록 완료)
- `undefined-lab`의 `/codex review`, `/claude review` 슬래시 커맨드 잡 로직을 재사용하되, 수동 트리거 대신 PR 생성/멘션 시 자동 실행되도록 변경

## 필요 사전 작업 (이 PR만으로는 동작 안 함)
- `sandbox-load-test`에 self-hosted mac 러너(`[self-hosted, macOS, X64]`) 등록 필요 — 현재 이 저장소엔 러너가 없음
- 러너 머신에 `claude`/`codex` CLI 로그인 세션 필요

Closes #https://github.com/eottabom/engineering-log/issues/457

## Test plan
- [ ] 러너 등록 후 PR open 시 두 리뷰가 정상적으로 달리는지 확인
- [ ] PR 코멘트에 `@eottabom-review-bot` 멘션 시 재리뷰가 도는지 확인
- [ ] `claude` 로그인 만료 시 경고 코멘트가 정상적으로 달리는지 확인