### PR TITLE
fix: 리뷰 봇 경고 코멘트에 엔진 이름 명시

### DIFF
--- a/.github/scripts/claude-review-run.sh
+++ b/.github/scripts/claude-review-run.sh
@@ -22,7 +22,7 @@ Steps:
    The 'body' field must use this exact markdown structure:
 
 {
-  "body": "## 🤖 eottabom-claude-review\n\n### 📊 종합 평가\n\n| 항목 | 평가 |\n|------|------|\n| ✅ Correctness | <가능 / 불가 + 한 줄 이유> |\n| 🔁 Regression Risk | <🔴 매우 높음 / 🟡 보통 / 🟢 낮음 + 한 줄 이유> |\n| ⚠️ Risky Changes | <있음: 내용 요약 / 없음> |\n| 🧪 Missing Tests | <있음: 내용 요약 / 없음> |\n\n### 📝 상세 리뷰\n\n<상세 리뷰 내용을 마크다운으로 작성. 파일명, 라인, 근거를 구체적으로>",
+  "body": "## 🤖 eottabom-claude-review-bot\n\n### 📊 종합 평가\n\n| 항목 | 평가 |\n|------|------|\n| ✅ Correctness | <가능 / 불가 + 한 줄 이유> |\n| 🔁 Regression Risk | <🔴 매우 높음 / 🟡 보통 / 🟢 낮음 + 한 줄 이유> |\n| ⚠️ Risky Changes | <있음: 내용 요약 / 없음> |\n| 🧪 Missing Tests | <있음: 내용 요약 / 없음> |\n\n### 📝 상세 리뷰\n\n<상세 리뷰 내용을 마크다운으로 작성. 파일명, 라인, 근거를 구체적으로>",
   "event": "COMMENT",
   "comments": [
     {

--- a/.github/scripts/codex-review-run.sh
+++ b/.github/scripts/codex-review-run.sh
@@ -22,7 +22,7 @@ Steps:
 6. Write the review to ${REVIEW_FILE} in this exact JSON format.
    The 'body' field must use this exact markdown structure:
 {
-  "body": "## 🤖 eottabom-codex-review\n\n### 📊 종합 평가\n\n| 항목 | 평가 |\n|------|------|\n| ✅ Correctness | <가능 / 불가 + 한 줄 이유> |\n| 🔁 Regression Risk | <🔴 매우 높음 / 🟡 보통 / 🟢 낮음 + 한 줄 이유> |\n| ⚠️ Risky Changes | <있음: 내용 요약 / 없음> |\n| 🧪 Missing Tests | <있음: 내용 요약 / 없음> |\n\n### 📝 상세 리뷰\n\n<상세 리뷰 내용을 마크다운으로 작성. 파일명, 라인, 근거를 구체적으로>",
+  "body": "## 🤖 eottabom-codex-review-bot\n\n### 📊 종합 평가\n\n| 항목 | 평가 |\n|------|------|\n| ✅ Correctness | <가능 / 불가 + 한 줄 이유> |\n| 🔁 Regression Risk | <🔴 매우 높음 / 🟡 보통 / 🟢 낮음 + 한 줄 이유> |\n| ⚠️ Risky Changes | <있음: 내용 요약 / 없음> |\n| 🧪 Missing Tests | <있음: 내용 요약 / 없음> |\n\n### 📝 상세 리뷰\n\n<상세 리뷰 내용을 마크다운으로 작성. 파일명, 라인, 근거를 구체적으로>",
   "event": "COMMENT",
   "comments": [
     {

--- a/.github/workflows/pr-auto-review.yml
+++ b/.github/workflows/pr-auto-review.yml
@@ -49,7 +49,7 @@ jobs:
             echo "logged_in=true" >> "$GITHUB_OUTPUT"
           else
             echo "logged_in=false" >> "$GITHUB_OUTPUT"
-            gh pr comment "$PR_NUMBER" --repo eottabom/sandbox-load-test --body "⚠️ **eottabom-review-bot** self-hosted 러너의 \`claude\` CLI 로그인 세션이 만료되어 자동 리뷰를 실행할 수 없습니다. 러너 머신에서 \`claude /login\`으로 재로그인해 주세요."
+            gh pr comment "$PR_NUMBER" --repo eottabom/sandbox-load-test --body "⚠️ **eottabom-claude-review-bot** self-hosted 러너의 \`claude\` CLI 로그인 세션이 만료되어 자동 리뷰를 실행할 수 없습니다. 러너 머신에서 \`claude /login\`으로 재로그인해 주세요."
           fi
 
       - name: Run Claude review
@@ -121,7 +121,7 @@ jobs:
             echo "logged_in=true" >> "$GITHUB_OUTPUT"
           else
             echo "logged_in=false" >> "$GITHUB_OUTPUT"
-            gh pr comment "$PR_NUMBER" --repo eottabom/sandbox-load-test --body "⚠️ **eottabom-review-bot** self-hosted 러너의 \`codex\` CLI 로그인 세션이 만료되어 자동 리뷰를 실행할 수 없습니다. 러너 머신에서 \`codex login\`으로 재로그인해 주세요."
+            gh pr comment "$PR_NUMBER" --repo eottabom/sandbox-load-test --body "⚠️ **eottabom-codex-review-bot** self-hosted 러너의 \`codex\` CLI 로그인 세션이 만료되어 자동 리뷰를 실행할 수 없습니다. 러너 머신에서 \`codex login\`으로 재로그인해 주세요."
           fi
 
       - name: Run Codex review

--- a/.github/workflows/pr-mention-review.yml
+++ b/.github/workflows/pr-mention-review.yml
@@ -76,7 +76,7 @@ jobs:
             echo "logged_in=true" >> "$GITHUB_OUTPUT"
           else
             echo "logged_in=false" >> "$GITHUB_OUTPUT"
-            gh pr comment "$PR_NUMBER" --repo eottabom/sandbox-load-test --body "⚠️ **eottabom-review-bot** self-hosted 러너의 \`claude\` CLI 로그인 세션이 만료되어 재리뷰를 실행할 수 없습니다. 러너 머신에서 \`claude /login\`으로 재로그인해 주세요."
+            gh pr comment "$PR_NUMBER" --repo eottabom/sandbox-load-test --body "⚠️ **eottabom-claude-review-bot** self-hosted 러너의 \`claude\` CLI 로그인 세션이 만료되어 재리뷰를 실행할 수 없습니다. 러너 머신에서 \`claude /login\`으로 재로그인해 주세요."
           fi
 
       - name: Run Claude review
@@ -175,7 +175,7 @@ jobs:
             echo "logged_in=true" >> "$GITHUB_OUTPUT"
           else
             echo "logged_in=false" >> "$GITHUB_OUTPUT"
-            gh pr comment "$PR_NUMBER" --repo eottabom/sandbox-load-test --body "⚠️ **eottabom-review-bot** self-hosted 러너의 \`codex\` CLI 로그인 세션이 만료되어 재리뷰를 실행할 수 없습니다. 러너 머신에서 \`codex login\`으로 재로그인해 주세요."
+            gh pr comment "$PR_NUMBER" --repo eottabom/sandbox-load-test --body "⚠️ **eottabom-codex-review-bot** self-hosted 러너의 \`codex\` CLI 로그인 세션이 만료되어 재리뷰를 실행할 수 없습니다. 러너 머신에서 \`codex login\`으로 재로그인해 주세요."
           fi
 
       - name: Run Codex review


### PR DESCRIPTION
## Summary
- 로그인 만료 경고가 전부 "eottabom-review-bot"으로만 찍혀 claude/codex 중 어느 CLI 세션이 만료됐는지 구분 안 되던 문제 수정
- eottabom-claude-review-bot / eottabom-codex-review-bot 으로 분리, 리뷰 본문 헤더도 동일하게 통일

## Test plan
- [ ] self-hosted 러너 등록 후 로그인 만료 상황 재현해 경고 코멘트에 엔진 이름이 맞게 찍히는지 확인